### PR TITLE
Fix build error on uint*_t types

### DIFF
--- a/core/src/device/amcInBand.h
+++ b/core/src/device/amcInBand.h
@@ -5,6 +5,7 @@
  */
 
 #include <string>
+#include <cstdint>
 namespace xpum {
 
 std::string add_two_hex_string(std::string str1, std::string str2);

--- a/core/src/infrastructure/device_util_by_proc.h
+++ b/core/src/infrastructure/device_util_by_proc.h
@@ -6,6 +6,7 @@
 
 #pragma once
 #include <string>
+#include <cstdint>
 
 namespace xpum {
 


### PR DESCRIPTION
On Ubuntu with gcc (Ubuntu 13.2.0-13ubuntu1) 13.2.0 We have build errors related to uint*_t type definitions.

core/src/infrastructure/device_util_by_proc.h:14:5: error: ‘uint32_t’ does not name a type
   14 |     uint32_t deviceId;

To fix this error, add include <cstdint> to appropriate header files.