### PR TITLE
Fix two typos in CLI

### DIFF
--- a/cli/src/cli_resource.cpp
+++ b/cli/src/cli_resource.cpp
@@ -13,7 +13,7 @@ namespace xpum::cli {
 namespace {
 #ifdef DAEMONLESS
 std::unordered_map<std::string, std::string> string_table = {
-    {"CLI_APP_DESC", "Intel XPU System Management Interface -- v" CLI_VERSION_IN_HELP "\nIntel XPU System Management Interface provides the Intel datacenter GPU model. It can also be used to update the firmware.\nIntel XPU System Management Interface is based on Intel oneAPI Level Zero. Before using Intel XPU System Management Interface, the GPU driver and Intel oneAPI Level Zero should be installed rightly.\n\nSupported devcies:\n - Intel Data Center GPU"}};
+    {"CLI_APP_DESC", "Intel XPU System Management Interface -- v" CLI_VERSION_IN_HELP "\nIntel XPU System Management Interface provides the Intel datacenter GPU model. It can also be used to update the firmware.\nIntel XPU System Management Interface is based on Intel oneAPI Level Zero. Before using Intel XPU System Management Interface, the GPU driver and Intel oneAPI Level Zero should be installed rightly.\n\nSupported devices:\n - Intel Data Center GPU"}};
 #else
 std::unordered_map<std::string, std::string> string_table = {
     {"CLI_APP_DESC", "Intel XPU Manager Command Line Interface -- v" CLI_VERSION_IN_HELP "\nIntel XPU Manager Command Line Interface provides the Intel data center GPU model and monitoring capabilities. It can also be used to change the Intel data center GPU settings and update the firmware.\nIntel XPU Manager is based on Intel oneAPI Level Zero. Before using Intel XPU Manager, the GPU driver and Intel oneAPI Level Zero should be installed rightly.\n\nSupported devices:\n  - Intel Data Center GPU "}};

--- a/windows/winxpum/cli/src/cli_resource.cpp
+++ b/windows/winxpum/cli/src/cli_resource.cpp
@@ -14,7 +14,7 @@ namespace xpum::cli {
     namespace {
         std::string CLI_VERSION_IN_HELP = std::to_string(VER_VERSION_MAJOR) + "." + std::to_string(VER_VERSION_MINOR);
         std::unordered_map<std::string, std::string> string_table = {
-                {"CLI_APP_DESC", "Intel XPU System Management Interface -- v" + CLI_VERSION_IN_HELP + "\nIntel XPU System Management Interface provides the Intel datacenter GPU model. It can also be used to update the firmware.\nIntel XPU System Management Interface is based on Intel oneAPI Level Zero. Before using Intel XPU System Management Interface, the GPU driver and Intel oneAPI Level Zero should be installed rightly.\n\nSupported devcies:\n - Intel Data Center GPU"}};
+                {"CLI_APP_DESC", "Intel XPU System Management Interface -- v" + CLI_VERSION_IN_HELP + "\nIntel XPU System Management Interface provides the Intel datacenter GPU model. It can also be used to update the firmware.\nIntel XPU System Management Interface is based on Intel oneAPI Level Zero. Before using Intel XPU System Management Interface, the GPU driver and Intel oneAPI Level Zero should be installed rightly.\n\nSupported devices:\n - Intel Data Center GPU"}};
 
     } // namespace
 


### PR DESCRIPTION
Fixed wrong spelling of `devices` in two places.